### PR TITLE
Improve bracket KaTeX normalization and tests

### DIFF
--- a/__tests__/bracket-math-open-fence.test.ts
+++ b/__tests__/bracket-math-open-fence.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'bun:test';
+import { h } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import { StreamMarkdown } from '../src/StreamMarkdown';
+
+// Simulates user scenario: many bracket math blocks first, later an open progressive fenced code block starts.
+// We stream chunk by chunk ensuring earlier math does not "fall back" to plain text when the open fence appears.
+
+const introMath =
+    `Intro text before math.\n\n` +
+    Array.from(
+        { length: 5 },
+        (_, i) => `Line ${i + 1}\n\\[ a_${i} = b_${i} + c_${i} \\]\n`
+    ).join('\n');
+
+const midContent = `Some narrative paragraphs here to push content size.\n\nMore lines...\n\n`;
+
+const openFenceStart =
+    '```ts\n// progressive code start\nexport const value = 1;';
+
+// Build streaming sequence: we cut the combined text into small slices (like the demo) up to just after opening fence.
+const fullSoFar = introMath + midContent + openFenceStart;
+const chunks = fullSoFar.match(/.{1,120}/gs) || []; // smallish chunks
+
+describe('bracket math survives after progressive code fence opens', () => {
+    it('keeps previously rendered bracket math as KaTeX', async () => {
+        let acc = '';
+        let lastHtml = '';
+        const katexCounts: number[] = [];
+        for (let i = 0; i < chunks.length; i++) {
+            acc += chunks[i];
+            const app = h(StreamMarkdown, { content: acc });
+            lastHtml = await renderToString(app);
+            const count = (lastHtml.match(/katex-display/g) || []).length;
+            katexCounts.push(count);
+        }
+        // After final chunk the number of display math blocks should equal the number we introduced (5)
+        const finalCount = katexCounts[katexCounts.length - 1];
+        expect(finalCount).toBeGreaterThanOrEqual(5);
+        // Verify monotonic non-decreasing (they should not disappear then reappear)
+        for (let i = 1; i < katexCounts.length; i++) {
+            const prev = katexCounts[i - 1]!; // non-null assertion (array index always valid here)
+            expect(katexCounts[i]).toBeGreaterThanOrEqual(prev);
+        }
+        // Sanity: code block is present as progressive open fence (no closing fence yet)
+        expect(lastHtml).toContain('data-streamdown="code-block"');
+    });
+});

--- a/__tests__/katex-streaming.test.ts
+++ b/__tests__/katex-streaming.test.ts
@@ -1,0 +1,124 @@
+const baseChunks: string[] = [
+    `好的！KaTeX 是一个非常流行的数学公式渲染引擎。下面是一些常见的数学公式示例，使用 KaTeX 语法：
+
+### 基本公式
+1. **线性方程**：
+   \\[ y = mx + b \\]`,
+    `2. **二次方程**：
+   \\[ ax^2 + bx + c = 0 \\]`,
+    '### 17. Matrix Math\n',
+    '$$\\begin{matrix}1 & 2\\\\ 3 & 4\\end{matrix}$$\n',
+    '### 18. Syntax Highlight Sampler\n',
+    'Below are multiple fenced code blocks to exercise Shiki multi-language highlighting.\n',
+    '```python\nimport math\n\n# quick computation\nvals = [math.sin(x/10) for x in range(5)]\nprint(vals)\n```\n\n',
+    '```bash\n#!/usr/bin/env bash\nset -euo pipefail\necho "Highlight test" | tr a-z A-Z\n```\n\n',
+    '```json\n{"demo":true,"items":[1,2,3],"nested":{"ok":1}}\n```\n\n',
+    '```diff\n@@ Added feature @@\n+ new line\n- old line\n```\n\n',
+    '### 19. Progressive Code Block (Split Streaming Test)\n',
+    '```js\n', // opening fence only
+    'function greet(name) {\n',
+    "  console.log('hi ' + name);\n",
+    '}\n',
+    '// more lines incoming...\n',
+    'for (let i=0;i<3;i++) console.log(i);\n',
+    'const obj = { a: 1, b: 2 };\n',
+    '/* simulate long code arriving line by line */\n',
+    'async function main() {\n',
+    '  await new Promise(r => setTimeout(r, 10));\n',
+    "  console.log('done');\n",
+    '}\n',
+    'main();\n',
+    '```\n\n', // closing fence arrives much later
+    '### 20. Incomplete Constructs Demo (start)\n',
+    'We now stream several *intentionally* broken / partial elements.\n\n',
+    '#### 20.a Second Progressive Code Fence (opens only)\n',
+    '```ts\n',
+    'export async function partialFeature(id: string) {\n',
+    '  const data = await fetch(`/api/item/${id}`);\n',
+    '  // still streaming more logic...\n',
+    '  if (!data.ok) {\n',
+    '    throw new Error("failed");\n',
+    '  }\n',
+    '  const json = await data.json();\n',
+    '  return json.value', // (no trailing newline yet, keep fence open)
+    '\n',
+    '#### 20.b Inline formatting starts (no closes yet)\n',
+    'This line has *italic start and **bold start plus `code start and an unmatched link [Example',
+    '\n',
+];
+
+// Debug streaming test: accumulate chunks, render after each, and log diagnostics.
+// We log the entire rendered HTML every 3 pushes (after chunk indices 2,5,8,...) and whenever
+// the chunk containing the "### 19. Progressive Code Block" heading is processed.
+
+import { describe, it, expect } from 'bun:test';
+import { h } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import { StreamMarkdown } from '../src/StreamMarkdown';
+
+function containsRenderedDisplayMath(html: string, snippet: string): boolean {
+    // Heuristic: snippet appears inside a katex-display block span
+    const idx = html.indexOf(snippet);
+    if (idx === -1) return false;
+    // Look backward a bit for a katex-display wrapper
+    const windowStart = Math.max(0, idx - 400);
+    const context = html.slice(windowStart, idx + snippet.length + 50);
+    return /katex-display/.test(context);
+}
+
+describe('DEBUG: KaTeX streaming around progressive code fence', () => {
+    it('logs snapshots to investigate bracket math regression', async () => {
+        let acc = '';
+        const targetExpr = 'y = mx + b';
+        const snapshots: {
+            step: number;
+            displayCount: number;
+            exprRendered: boolean;
+            openFences: number;
+            has19: boolean;
+        }[] = [];
+        for (let i = 0; i < baseChunks.length; i++) {
+            const chunk = baseChunks[i];
+            acc += chunk;
+            const app = h(StreamMarkdown, { content: acc });
+            const html = await renderToString(app);
+            const displayCount = (html.match(/katex-display/g) || []).length;
+            const exprRendered = containsRenderedDisplayMath(html, targetExpr);
+            const openFences = (acc.match(/```/g) || []).length % 2; // 1 if an unclosed fenced code block is currently open
+            const has19 = /### 19\. Progressive Code Block/.test(acc);
+            snapshots.push({
+                step: i + 1,
+                displayCount,
+                exprRendered,
+                openFences,
+                has19,
+            });
+
+            const shouldDump = i % 3 === 2 || has19;
+            if (shouldDump) {
+                // Full HTML dump for debug (explicit markers for log scanning)
+                console.log(
+                    '\n===== STREAM DEBUG DUMP START step=' + (i + 1) + ' ====='
+                );
+                console.log(
+                    'displayCount=' +
+                        displayCount +
+                        ' exprRendered=' +
+                        exprRendered +
+                        ' openFence=' +
+                        openFences +
+                        ' has19=' +
+                        has19
+                );
+                console.log(html);
+                console.log(
+                    '===== STREAM DEBUG DUMP END step=' + (i + 1) + ' =====\n'
+                );
+            }
+        }
+        // Basic sanity: we should end with at least one rendered display math block.
+        const last = snapshots[snapshots.length - 1]!; // guaranteed because baseChunks non-empty
+        expect(last.displayCount).toBeGreaterThan(0);
+        expect(last.exprRendered).toBe(true);
+    }, 20000);
+});

--- a/__tests__/latex-brackets.test.ts
+++ b/__tests__/latex-brackets.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'bun:test';
+import { h } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import { StreamMarkdown } from '../src/StreamMarkdown';
+
+const aiResponse = `好的！KaTeX 是一个非常流行的数学公式渲染引擎。下面是一些常见的数学公式示例，使用 KaTeX 语法：
+
+### 基本公式
+1. **线性方程**：
+   \\[ y = mx + b \\]
+
+2. **二次方程**：
+   \\[ ax^2 + bx + c = 0 \\]
+
+3. **指数函数**：
+   \\[ y = e^x \\]
+
+### 代数公式
+1. **平方差公式**：
+   \\[ a^2 - b^2 = (a - b)(a + b) \\]
+
+2. **完全平方公式**：
+   \\[ (a + b)^2 = a^2 + 2ab + b^2 \\]
+   \\[ (a - b)^2 = a^2 - 2ab + b^2 \\]
+
+### 几何公式
+1. **圆的面积**：
+   \\[ A = \pi r^2 \\]
+
+2. **圆的周长**：
+   \\[ C = 2\pi r \\]
+
+3. **勾股定理**：
+   \\[ a^2 + b^2 = c^2 \\]
+
+### 微积分公式
+1. **导数**：
+   \\[ \\frac{d}{dx} (x^n) = nx^{n-1} \\]
+
+2. **不定积分**：
+   \\[ \\int x^n \, dx = \\frac{x^{n+1}}{n+1} + C \\]
+
+3. **定积分**：
+   \\[ \\int_a^b x^n \, dx = \\left[ \\frac{x^{n+1}}{n+1} \\right]_a^b \\]
+
+### 线性代数公式
+1. **矩阵乘法**：
+   \\[ \\begin{pmatrix} a & b \\ c & d \\end{pmatrix} \\begin{pmatrix} e \\ f \\end{pmatrix} = \\begin{pmatrix} ae + bf \\ ce + df \\end{pmatrix} \\]
+
+2. **行列式**：
+   \\[ \\det \\begin{pmatrix} a & b \\ c & d \\end{pmatrix} = ad - bc \\]
+
+### 概率公式
+1. **条件概率**：
+   \\[ P(A|B) = \\frac{P(A \\cap B)}{P(B)} \\]
+
+2. **贝叶斯定理**：
+   \\[ P(A|B) = \\frac{P(B|A)P(A)}{P(B)} \\]
+`;
+
+describe('KaTeX bracket syntax rendering', () => {
+    it('renders AI style display math using \\[ delimiters', async () => {
+        const html = await renderToString(
+            h(StreamMarkdown, { content: aiResponse })
+        );
+
+        const displayCount = (html.match(/katex-display/g) || []).length;
+
+        // We expect every display math block to be rendered by KaTeX.
+        expect(displayCount).toBeGreaterThanOrEqual(12);
+    });
+
+    it('renders bracket math nested inside blockquotes and lists', async () => {
+        const nestedContent = [
+            '> 引用段落',
+            '> \\[ e^{i\\pi} + 1 = 0 \\]',
+            '>',
+            '> 继续说明。',
+            '',
+            '- 列表项：',
+            '    \\[ a^2 + b^2 = c^2 \\]',
+            '',
+            '结尾说明。',
+        ].join('\n');
+
+        const html = await renderToString(
+            h(StreamMarkdown, { content: nestedContent })
+        );
+
+        const displayCount = (html.match(/katex-display/g) || []).length;
+        expect(displayCount).toBe(2);
+        expect(html).toContain('<blockquote');
+        expect(html).not.toContain('\\\\[');
+    });
+
+    it('ignores bracket syntax inside fenced code blocks', async () => {
+        const fencedContent = [
+            'Plain code:',
+            '```',
+            '\\[shouldStay\\]',
+            '```',
+            '',
+            '> ~~~',
+            '> \\[stillStay\\]',
+            '> ~~~',
+            '>',
+            '\\[ x^2 + y^2 = z^2 \\]',
+        ].join('\n');
+
+        const html = await renderToString(
+            h(StreamMarkdown, { content: fencedContent })
+        );
+
+        const displayCount = (html.match(/katex-display/g) || []).length;
+        expect(displayCount).toBe(1);
+        expect(html).toContain('shouldStay');
+        expect(html).toContain('stillStay');
+    });
+});

--- a/__tests__/latex-inline-brackets.test.ts
+++ b/__tests__/latex-inline-brackets.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'bun:test';
+import { h } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import { StreamMarkdown } from '../src/StreamMarkdown';
+
+// Ensures inline bracket math within a paragraph is lifted to a display block.
+
+describe('inline bracket math normalization', () => {
+    it('converts inline \\[ a + b = c \\] into display KaTeX', async () => {
+        const md = 'Intro text then \\[ a + b = c \\] continues same line.';
+        const html = await renderToString(h(StreamMarkdown, { content: md }));
+        const displayCount = (html.match(/katex-display/g) || []).length;
+        expect(displayCount).toBeGreaterThanOrEqual(1);
+        expect(html).toContain('a + b = c');
+    });
+});

--- a/__tests__/latex.test.ts
+++ b/__tests__/latex.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { fixDollarSignMath, fixMatrix } from '../lib/latex-utils';
+import {
+    fixDollarSignMath,
+    fixMatrix,
+    normalizeBracketDisplayMath,
+} from '../lib/latex-utils';
 
 describe('latex utilities', () => {
     it('optional helper does not alter valid inline math', () => {
@@ -12,5 +16,30 @@ describe('latex utilities', () => {
         const output = fixMatrix(input);
         expect(output).toContain('1 & 2 \\\\');
         expect(output).toContain('3 & 4');
+    });
+
+    it('normalizes bracket math inside blockquotes into $$ blocks', () => {
+        const input = ['> 引用', '> \\[ x^2 \\]', '> 结束'].join('\n');
+        const output = normalizeBracketDisplayMath(input);
+        expect(output).toContain('> $$');
+        expect(output).toContain('> x^2');
+        expect(output).toContain('> $$\n> 结束');
+        expect(output).not.toContain('\\\\[');
+    });
+
+    it('skips normalization inside indented fences', () => {
+        const input = ['> ```', '> \\[raw\\]', '> ```', '', '\\[ real \\]'].join('\n');
+        const output = normalizeBracketDisplayMath(input);
+        expect(output).toContain('> ```');
+        expect(output).toContain('> \\[raw\\]');
+        expect(output).toMatch(/\$\$\s*\nreal\s*\n\$\$/);
+    });
+
+    it('keeps trailing text after single-line closures in blockquotes', () => {
+        const input = '> \\[ x^2 \\] 继续';
+        const output = normalizeBracketDisplayMath(input);
+        expect(output).toContain('> $$');
+        expect(output).toContain('> x^2');
+        expect(output).toContain('> $$\n> 继续');
     });
 });

--- a/examples/basic/App.vue
+++ b/examples/basic/App.vue
@@ -13,6 +13,62 @@ let timer: number | null = null;
 // Base demo chunk sequence (could come from a real server stream).
 // We'll clone / extend this for stress testing.
 const baseChunks: string[] = [
+    `好的！KaTeX 是一个非常流行的数学公式渲染引擎。下面是一些常见的数学公式示例，使用 KaTeX 语法：
+
+### 基本公式
+1. **线性方程**：
+   \\[ y = mx + b \\]`,
+
+    `2. **二次方程**：
+   \\[ ax^2 + bx + c = 0 \\]
+
+3. **指数函数**：
+   \\[ y =`,
+    `e^x \\]`,
+
+    `### 代数公式
+1. **平方差公式**：
+   \\[ a^2 - b^2 = (a - b)(a + b) \\]
+
+2. **完全平方公式**：
+   \\[ (a + b)^2 = a^2 + 2ab + b^2 \\]
+   \\[ (a - b)^2 = a^2 - 2ab + b^2 \\]
+
+### 几何公式
+1. **圆的面积**：
+   \\[ A = \pi r^2 \\]`,
+
+    `2. **圆的周长**：
+   \\[ C = 2\pi r \\]
+
+3. **勾股定理**：
+   \\[ a^2 + `,
+    `b^2 = c^2 \\]
+
+### 微积分公式
+1. **导数**：
+   \\[ \\frac{d}{dx} (x^n) = nx^{n-1} \\]
+
+2. **不定积分**：
+   \\[ \\int x^n \, dx = \\frac{x^{n+1}}{n+1} + C \\]
+
+3. **定积分**：
+   \\[ \\int_a^b x^n \, dx = \\left[ \\frac{x^{n+1}}{n+1} \\right]_a^b \\]
+
+### 线性代数公式
+1. **矩阵乘法**：
+   \\[ \\begin{pmatrix} a & b \\ c & d \\end{pmatrix} \\begin{pmatrix} e \\ f \\end{pmatrix} = \\begin{pmatrix} ae + bf \\ ce + df \\end{pmatrix} \\]
+
+2. **行列式**：
+   \\[ \\det \\begin{pmatrix} a & b \\ c & d \\end{pmatrix} = ad - bc \\]
+
+### 概率公式
+1. **条件概率**：
+   \\[ P(A|B) = \\frac{P(A \\cap B)}{P(B)} \\]
+
+2. **贝叶斯定理**：
+   \\[ P(A|B) = \\frac{P(B|A)P(A)}{P(B)} \\]
+`,
     '$ BROKEN $\n\n',
     '$ 100 dollars x 100x $\n\n',
     '# Hello Vuedown Streaming Demo\n\n',

--- a/lib/latex-utils.ts
+++ b/lib/latex-utils.ts
@@ -153,10 +153,10 @@ export function normalizeBracketDisplayMath(content: string): string {
         if (!inMath) {
             const fenceMatch = line.match(/^(\s*(?:>\s*)*)([`~]{3,})/);
             if (fenceMatch) {
-                const marker = fenceMatch[2] ?? '';
+                const marker = fenceMatch[2];
                 if (!inFence) {
                     inFence = true;
-                    fenceMarker = marker[0] ?? '';
+                    fenceMarker = marker[0];
                     fenceLength = marker.length;
                 } else if (
                     marker[0] === fenceMarker &&
@@ -201,7 +201,7 @@ export function normalizeBracketDisplayMath(content: string): string {
             const closingIndex = remainder.indexOf('\\]');
             if (closingIndex !== -1) {
                 const body = remainder.slice(0, closingIndex);
-                if (body.trim().length > 0 || body.length > 0) {
+                if (body.length > 0) {
                     pushMathLine(stripMathIndent(body).trimStart());
                 }
                 output.push(mathIndent + '$$');
@@ -219,7 +219,7 @@ export function normalizeBracketDisplayMath(content: string): string {
         const closingIndex = line.indexOf('\\]');
         if (closingIndex !== -1) {
             const before = line.slice(0, closingIndex);
-            if (before.trim().length > 0 || before.length > 0) {
+            if (before.length > 0) {
                 pushMathLine(stripMathIndent(before));
             }
             output.push(mathIndent + '$$');
@@ -240,8 +240,8 @@ export function normalizeBracketDisplayMath(content: string): string {
     let fenceChar2 = '';
     let fenceLen2 = 0;
     for (const rawLine of output) {
-        // Guard against undefined when using noUncheckedIndexedAccess (though rawLine is always string in for..of)
-        const line: string = rawLine ?? '';
+        // rawLine is always string in for..of
+        const line: string = rawLine;
         // Match fences possibly preceded by blockquote markers similar to first pass
         const fenceMatch = line.match(/^(\s*(?:>\s*)*)([`~]{3,})/);
         if (fenceMatch) {

--- a/lib/latex-utils.ts
+++ b/lib/latex-utils.ts
@@ -154,9 +154,19 @@ export function normalizeBracketDisplayMath(content: string): string {
             const fenceMatch = line.match(/^(\s*(?:>\s*)*)([`~]{3,})/);
             if (fenceMatch) {
                 const marker = fenceMatch[2];
+                // If the regex unexpectedly didn't capture a marker, treat line as normal content.
+                if (!marker) {
+                    output.push(line);
+                    continue;
+                }
                 if (!inFence) {
+                    if (!marker.length) {
+                        // safety: empty string shouldn't happen, treat as normal line
+                        output.push(line);
+                        continue;
+                    }
                     inFence = true;
-                    fenceMarker = marker[0];
+                    fenceMarker = marker[0]!;
                     fenceLength = marker.length;
                 } else if (
                     marker[0] === fenceMarker &&

--- a/lib/latex-utils.ts
+++ b/lib/latex-utils.ts
@@ -188,13 +188,8 @@ export function normalizeBracketDisplayMath(content: string): string {
                 mathStripIndent.includes('>') && !/\s$/.test(mathStripIndent)
                     ? mathStripIndent + ' '
                     : mathStripIndent;
-            if (
-                output.length > 0 &&
-                output[output.length - 1]?.trim().length
-            ) {
-                output.push(
-                    mathIndent.includes('>') ? mathIndent : ''
-                );
+            if (output.length > 0 && output[output.length - 1]?.trim().length) {
+                output.push(mathIndent.includes('>') ? mathIndent : '');
             }
             output.push(mathIndent + '$$');
             const remainder = startMatch[2] ?? '';
@@ -250,10 +245,7 @@ export function normalizeBracketDisplayMath(content: string): string {
                 inFence2 = true;
                 fenceChar2 = marker[0] ?? '';
                 fenceLen2 = marker.length;
-            } else if (
-                marker[0] === fenceChar2 &&
-                marker.length >= fenceLen2
-            ) {
+            } else if (marker[0] === fenceChar2 && marker.length >= fenceLen2) {
                 inFence2 = false;
                 fenceChar2 = '';
                 fenceLen2 = 0;

--- a/src/StreamMarkdown.ts
+++ b/src/StreamMarkdown.ts
@@ -354,6 +354,9 @@ export const StreamMarkdown = defineComponent({
             const blocks = merged
                 .map((b) => b)
                 .map((b) =>
+                    // Use trimEnd() instead of trim() to preserve leading whitespace,
+                    // which is important for markdown elements like code blocks and lists.
+                    // Only trailing whitespace is removed to avoid breaking indented content.
                     props.parseIncompleteMarkdown
                         ? parseIncompleteMarkdown(b.trimEnd())
                         : b

--- a/src/StreamMarkdown.ts
+++ b/src/StreamMarkdown.ts
@@ -11,7 +11,11 @@ import MermaidBlock from './components/MermaidBlock';
 import defaultComponents, { type ComponentMap } from './components/components';
 import { parseBlocks } from '../lib/parse-blocks';
 import { parseIncompleteMarkdown } from '../lib/parse-incomplete-markdown';
-import { fixMatrix, normalizeDisplayMath } from '../lib/latex-utils';
+import {
+    fixMatrix,
+    normalizeBracketDisplayMath,
+    normalizeDisplayMath,
+} from '../lib/latex-utils';
 import {
     hardenHref,
     hardenSrc,
@@ -284,6 +288,7 @@ export const StreamMarkdown = defineComponent({
             // breaking streaming scenarios where the closing delimiter arrives later.
             // (debug logging removed)
             let preprocessed = fixMatrix(markdownSrc);
+            preprocessed = normalizeBracketDisplayMath(preprocessed);
             const afterFix = preprocessed;
             preprocessed = normalizeDisplayMath(preprocessed);
             // (debug logging removed)
@@ -339,7 +344,7 @@ export const StreamMarkdown = defineComponent({
                 .map((b) => b)
                 .map((b) =>
                     props.parseIncompleteMarkdown
-                        ? parseIncompleteMarkdown(b.trim())
+                        ? parseIncompleteMarkdown(b.trimEnd())
                         : b
                 );
             // (debug logging removed)


### PR DESCRIPTION
## Summary
- expand KaTeX regression coverage to include blockquotes, lists, and fenced code scenarios
- add unit tests for bracket display math normalization to ensure blockquote support and fence skipping
- update `normalizeBracketDisplayMath` to respect blockquote prefixes, preserve indentation, and ignore fenced code while rewriting

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68c83f6f55088327b42bf97b568faf3c